### PR TITLE
refactor: hide demo multiple maps screen due to upcoming changes to paths prop

### DIFF
--- a/sample-app/src/App.tsx
+++ b/sample-app/src/App.tsx
@@ -11,7 +11,6 @@ import useCreateAdaptiveTheme from './hooks/useCreateAdaptiveTheme';
 import AboutScreen from './screens/AboutScreen';
 import MarkerMapScreen from './screens/MarkerMapScreen';
 import MenuScreen from './screens/MenuScreen';
-import MultipleMapsScreen from './screens/MultipleMapsScreen';
 import PlainMapScreen from './screens/PlainMapScreen';
 
 const Stack = createNativeStackNavigator();
@@ -61,11 +60,11 @@ export default function App() {
               options={screenOptions}
             />
 
-            <Stack.Screen
+            {/* <Stack.Screen
               name={Route.multipleMaps}
               component={MultipleMapsScreen}
               options={screenOptions}
-            />
+            /> */}
           </Stack.Navigator>
         </NavigationContainer>
       </MapProviderChoiceContextProvider>

--- a/sample-app/src/Routes.ts
+++ b/sample-app/src/Routes.ts
@@ -3,7 +3,7 @@ export enum Route {
   about = 'About app',
   plainMap = 'Plain map',
   markerMap = 'Marker map',
-  multipleMaps = 'Multiple maps',
+  // multipleMaps = 'Multiple maps',
 }
 
 export const RoutesDescriptions: Record<Route, string> = {
@@ -11,8 +11,8 @@ export const RoutesDescriptions: Record<Route, string> = {
   [Route.about]: 'About app',
   [Route.plainMap]: 'Interactive map without any additional features.',
   [Route.markerMap]: 'Interactive map with markers.',
-  [Route.multipleMaps]:
-    'Multiple maps from different providers displayed simultaneously.',
+  // [Route.multipleMaps]:
+  //   'Multiple maps from different providers displayed simultaneously.',
 };
 
 export default Route;

--- a/sample-app/src/screens/MenuScreen.tsx
+++ b/sample-app/src/screens/MenuScreen.tsx
@@ -8,11 +8,7 @@ import MenuListItem from '../components/MenuListItem';
 import useLogger from '../hooks/useLogger';
 import useMapProviderChoiceContext from '../hooks/useMapProviderChoice';
 
-const menuRoutes: Route[] = [
-  Route.plainMap,
-  Route.markerMap,
-  Route.multipleMaps,
-];
+const menuRoutes: Route[] = [Route.plainMap, Route.markerMap];
 
 export const MenuScreen = () => {
   const theme = useTheme();


### PR DESCRIPTION
## Summary

Hide the menu option for multiple maps screen, since this feature will be unavailable at least for some time after https://github.com/openmobilehub/react-native-omh-maps/tree/feat/OMHD-194-and-OMHD-195 is merged.

## Demo

N/A

## Checklist:

- [x] Documentation is up to date to reflect these changes
- [x] Created Unit tests
