### PR TITLE
fix: null pointer exception on old arch when unmounting entites after unmounting map fragment

### DIFF
--- a/packages/core/android/src/main/java/com/openmobilehub/android/rn/maps/core/viewmanagers/RNOmhMapsCoreViewManagerImpl.kt
+++ b/packages/core/android/src/main/java/com/openmobilehub/android/rn/maps/core/viewmanagers/RNOmhMapsCoreViewManagerImpl.kt
@@ -33,6 +33,7 @@ class RNOmhMapsCoreViewManagerImpl(private val reactContext: ReactContext) {
     var width: Int? = null
     private val mountedChildren = HashMap<Int, OmhMapEntity<*>>()
     private val addEntitiesQueue = mutableListOf<Pair<View, Int>>()
+    private var isMounted = false
 
     fun createViewInstance(reactContext: ThemedReactContext): FragmentContainerView {
         return FragmentContainerView(reactContext)
@@ -104,6 +105,11 @@ class RNOmhMapsCoreViewManagerImpl(private val reactContext: ReactContext) {
     }
 
     fun removeViewAt(index: Int) {
+        // note: on old RN architecture, RN unmounts the fragment first, and then the children
+        // which causes a NullPointerException when unmountEntity() triggers calls to underlying
+        // native entities, which are bound to a non-existent map that has already been unmounted
+        if (!isMounted) return
+
         // note: on old RN architecture, RN tries to unmount the child view
         // at index 0 even when it had never been added, thus the check is omitted in such case
         val child = mountedChildren[index]
@@ -125,6 +131,8 @@ class RNOmhMapsCoreViewManagerImpl(private val reactContext: ReactContext) {
                 val transaction = fragmentManager.beginTransaction()
                 transaction.remove(fragment)
                 transaction.commitNowAllowingStateLoss()
+
+                isMounted = false
             }
         }
     }
@@ -154,6 +162,8 @@ class RNOmhMapsCoreViewManagerImpl(private val reactContext: ReactContext) {
                 layoutChildren(view)
             }
             transaction.commitNowAllowingStateLoss()
+
+            isMounted = true
         }
     }
 


### PR DESCRIPTION
## Summary

A problem used to occur on RN old architecture: when the native `RNOmhMapsMarkerNativeComponent` would have to be unmounted, the new RN architecture would first unmount its children (`removeViewAt` in `RNOmhMapsCoreViewManager.kt`) and then the map fragment, however the old architecture apparently would first unmount the fragment and then the children, causing us to call `remove()` from `OmhMapEntity`'s `unmountEntity` on a non-existent map. This in turn would result in a `NullPointerException`.

This PR introduces a simple fix that makes `RNOmhMapsCoreViewManagerImpl` check if the map fragment is currently mounted in `removeViewAt` before performing any operations. This ensures proper behaviour on old RN architecture.

## Demo

N/A

## Checklist:

- [x] Documentation is up to date to reflect these changes
- [x] Created Unit tests