### PR TITLE
OMHD-318: add/remove reference polyline/polygons checkbox

### DIFF
--- a/sample-app/src/screens/demos/PolygonMapScreen.tsx
+++ b/sample-app/src/screens/demos/PolygonMapScreen.tsx
@@ -108,6 +108,8 @@ export const PolygonMapScreen = () => {
   const { showSnackbar } = useSnackbar();
 
   const omhMapRef = useRef<OmhMapViewRef | null>(null);
+  const [isReferencePolygonVisible, setIsReferencePolygonVisible] =
+    useState(false);
   const [outline, setOutline] = useState(customizablePolygonOutline);
   const [isClickable, setIsClickable] = useState(false);
   const [withHoles, setWithHoles] = useState(false);
@@ -246,6 +248,7 @@ export const PolygonMapScreen = () => {
             )}
           />
           <OmhPolygon
+            isVisible={isReferencePolygonVisible}
             outline={referencePolygonOutline}
             zIndex={2}
             clickable={true}
@@ -266,6 +269,11 @@ export const PolygonMapScreen = () => {
           <PanelButton
             onPress={handleRandomizeOutlineButtonPress}
             label="Randomize Outline"
+          />
+          <PanelCheckbox
+            label="Show Reference Polygon (Add/Remove)"
+            value={isReferencePolygonVisible}
+            onValueChange={setIsReferencePolygonVisible}
           />
           <PanelCheckbox
             label="Visible"

--- a/sample-app/src/screens/demos/PolylineMapScreen.tsx
+++ b/sample-app/src/screens/demos/PolylineMapScreen.tsx
@@ -140,6 +140,8 @@ export const PolylineMapScreen = () => {
   const { showSnackbar } = useSnackbar();
 
   const omhMapRef = useRef<OmhMapViewRef | null>(null);
+  const [isReferencePolylineVisible, setIsReferencePolylineVisible] =
+    useState(false);
   const [points, setPoints] = useState(customizablePolylinePoints);
   const [isClickable, setIsClickable] = useState(false);
   const [width, setWidth] = useState(defaultWidth);
@@ -312,6 +314,7 @@ export const PolylineMapScreen = () => {
             {...capProps}
           />
           <OmhPolyline
+            isVisible={isReferencePolylineVisible}
             points={referencePolylinePoints}
             zIndex={2}
             clickable={true}
@@ -332,6 +335,11 @@ export const PolylineMapScreen = () => {
           <PanelButton
             onPress={handleRandomizePointsButtonPress}
             label="Randomize Points"
+          />
+          <PanelCheckbox
+            label="Show Reference Polyline (Add/Remove)"
+            value={isReferencePolylineVisible}
+            onValueChange={setIsReferencePolylineVisible}
           />
           <PanelCheckbox
             label="Visible"


### PR DESCRIPTION
## Summary
- Reference polygon/polyline is now hidden by default
- Add checkbox to add/remove them

## Demo

https://github.com/openmobilehub/react-native-omh-maps/assets/28648651/a96de39c-9676-4844-882b-7feb02c6046b


## Checklist:

- [x] Documentation is up to date to reflect these changes
- [x] Created Unit tests

Closes: [OMHD-318](https://callstackio.atlassian.net/browse/OMHD-318)
