### PR TITLE
OMHD-323: Fix iOS app crashing

### DIFF
--- a/packages/core/src/components/mapView/OmhMapView.ios.tsx
+++ b/packages/core/src/components/mapView/OmhMapView.ios.tsx
@@ -31,7 +31,10 @@ export const OmhMapView = forwardRef<OmhMapViewRef, OmhMapViewProps>(
       zoomEnabled,
       rotateEnabled,
       onMapLoaded,
-      onMapReady,
+      // If onMapReady is undefined on AppleMaps it will throw an error on some RN versions.
+      // Read more: https://github.com/react-native-maps/react-native-maps/pull/4887
+      // Assigning an empty function to prevent this error.
+      onMapReady = () => {},
       onCameraIdle,
       onCameraMoveStarted,
       children,

--- a/sample-app/ios/RnOmhMapsExample.xcodeproj/project.pbxproj
+++ b/sample-app/ios/RnOmhMapsExample.xcodeproj/project.pbxproj
@@ -616,7 +616,11 @@
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
-				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-Wl",
+					"-ld_classic",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;
@@ -690,7 +694,11 @@
 					"-DFOLLY_USE_LIBCPP=1",
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 				);
-				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-Wl",
+					"-ld_classic",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;


### PR DESCRIPTION
## Summary

This PR fixes the app crashes for iOS when empty `onMapReady` callback is passed.

## Demo

https://github.com/openmobilehub/react-native-omh-maps/assets/23010554/5be6aa0c-fcdc-43e6-9e91-f970dba584b7

## Checklist:

- [x] Documentation is up to date to reflect these changes
- [x] Created Unit tests

Closes: [OMHD-323](https://callstackio.atlassian.net/browse/OMHD-323)
