### PR TITLE
Refactor: Update provider picker on iOS

### DIFF
--- a/sample-app/src/components/MapProviderPicker.tsx
+++ b/sample-app/src/components/MapProviderPicker.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { View, ViewProps } from 'react-native';
 import { useTheme } from 'react-native-paper';
 import RNPickerSelect from 'react-native-picker-select';
@@ -37,7 +37,6 @@ export default function MapProviderPicker({
     <View style={style}>
       <ControlParagraph centered={centeredLabel}>{label}</ControlParagraph>
       <RNPickerSelect
-        InputAccessoryView={(() => null) as unknown as ReactNode}
         onValueChange={(newProviderName: string) => {
           const newProvider = availableProviders.find(
             ({ name }) => name === newProviderName
@@ -64,6 +63,12 @@ export default function MapProviderPicker({
         style={{
           inputIOS: {
             paddingLeft: 16,
+          },
+          chevronUp: {
+            opacity: 0, // hide the chevron
+          },
+          chevronDown: {
+            opacity: 0, // hide the chevron
           },
         }}
       />


### PR DESCRIPTION
## Summary

This PR updates provider picker on iOS by enabling `Done` button. This change was requested by QA.

## Demo

Before:

https://github.com/openmobilehub/react-native-omh-maps/assets/23010554/b241a095-ba39-4485-9a2d-b9d0c512e84b

After:

https://github.com/openmobilehub/react-native-omh-maps/assets/23010554/5ec54af3-8280-4e83-9438-5674d6dca845

## Checklist:

- [x] Documentation is up to date to reflect these changes
- [x] Created Unit tests

Closes: n/a
