### PR TITLE
OMHD-371: fix create new plugin script

### DIFF
--- a/apps/sample-app/ios/RnOmhMapsExample.xcodeproj/project.pbxproj
+++ b/apps/sample-app/ios/RnOmhMapsExample.xcodeproj/project.pbxproj
@@ -500,7 +500,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.omh.maps.sample;
+				PRODUCT_BUNDLE_IDENTIFIER = com.openmobilehub.maps.sample;
 				PRODUCT_NAME = RnOmhMapsExample;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Omh Maps Sample Ad hoc";
@@ -532,7 +532,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.omh.maps.sample;
+				PRODUCT_BUNDLE_IDENTIFIER = com.openmobilehub.maps.sample;
 				PRODUCT_NAME = RnOmhMapsExample;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Omh Maps Sample Ad hoc";

--- a/packages/plugin-googlemaps/android/build.gradle
+++ b/packages/plugin-googlemaps/android/build.gradle
@@ -44,7 +44,7 @@ def supportsNamespace() {
 
 android {
     if (supportsNamespace()) {
-        namespace "com.omh.RNOmhMapsPluginGooglemaps"
+        namespace "com.openmobilehub.android.rn.maps.plugin.googlemaps"
 
         sourceSets {
             main {


### PR DESCRIPTION
## Summary

This PR introduces updates to the `yarn scripts createPlugin` script to:
- run RN codegen for Android automatically after creating a new plugin
- create a native module instead of view manager
- adjust package names properly

## Demo

N/A

## Checklist:

- [x] Documentation is up to date to reflect these changes
- [x] Created Unit tests


Closes: [OMHD-371](https://callstackio.atlassian.net/browse/OMHD-371)