### PR TITLE
OMHD-370: iOS Marker Draggable

### DIFF
--- a/apps/sample-app/src/screens/demos/MarkerMapScreen.tsx
+++ b/apps/sample-app/src/screens/demos/MarkerMapScreen.tsx
@@ -325,8 +325,6 @@ export const MarkerMapScreen = () => {
     }
   }, [supportedFeatures?.draggable]);
 
-  console.log(customizableMarkerColorRGB);
-
   return (
     <View style={demoStyles.rootContainer}>
       <View style={demoStyles.mapContainer}>
@@ -340,7 +338,6 @@ export const MarkerMapScreen = () => {
 
             const providerName = omhMapRef.current?.getProviderName();
 
-            console.log('provider name ' + providerName);
             setSupportedFeatures(getSupportedFeatures(providerName));
             setDisabledOptions(getDisabledOptions(providerName));
 

--- a/apps/sample-app/src/screens/demos/MarkerMapScreen.tsx
+++ b/apps/sample-app/src/screens/demos/MarkerMapScreen.tsx
@@ -41,6 +41,7 @@ import ANDROID_SUPPORTED_PROVIDERS = Constants.Demo.ANDROID_SUPPORTED_PROVIDERS;
 export enum MarkerIWTitles {
   CONFIGURABLE_TEST_MARKER = 'Configurable test marker',
   STATIC_ICON_MARKER_NON_DRAGGABLE = 'Static icon marker (non-draggable)',
+  STATIC_MARKER_NON_DRAGGABLE = 'Static marker (non-draggable)',
   STATIC_COLORED_MARKER_DRAGGABLE = 'Static colored marker (draggable)',
   STATIC_COLORED_MARKER_NON_DRAGGABLE = 'Static colored marker (non-draggable)',
 }
@@ -137,9 +138,9 @@ export const MarkerMapScreen = () => {
   const { showSnackbar } = useSnackbar();
 
   const omhMapRef = useRef<OmhMapViewRef | null>(null);
-  const [supportedFeatures, setSupportedFeatures] = useState(
-    getSupportedFeatures()
-  );
+  const [supportedFeatures, setSupportedFeatures] = useState<ReturnType<
+    typeof getSupportedFeatures
+  > | null>(null);
   const [disabledOptions, setDisabledOptions] = useState(getDisabledOptions());
 
   const configurableMarkerRef = useRef<OmhMarkerRef | null>(null);
@@ -150,6 +151,7 @@ export const MarkerMapScreen = () => {
     return {
       [MarkerIWTitles.CONFIGURABLE_TEST_MARKER]: configurableMarkerRef,
       [MarkerIWTitles.STATIC_ICON_MARKER_NON_DRAGGABLE]: iconMarkerRef,
+      [MarkerIWTitles.STATIC_MARKER_NON_DRAGGABLE]: iconMarkerRef,
       [MarkerIWTitles.STATIC_COLORED_MARKER_DRAGGABLE]: coloredMarkerRef,
       [MarkerIWTitles.STATIC_COLORED_MARKER_NON_DRAGGABLE]: coloredMarkerRef,
     };
@@ -185,6 +187,7 @@ export const MarkerMapScreen = () => {
   const [showInfoWindow, setShowInfoWindow] = useState({
     [MarkerIWTitles.CONFIGURABLE_TEST_MARKER]: false,
     [MarkerIWTitles.STATIC_ICON_MARKER_NON_DRAGGABLE]: false,
+    [MarkerIWTitles.STATIC_MARKER_NON_DRAGGABLE]: false,
     [MarkerIWTitles.STATIC_COLORED_MARKER_DRAGGABLE]: false,
     [MarkerIWTitles.STATIC_COLORED_MARKER_NON_DRAGGABLE]: false,
   } as Record<MarkerIWTitles, boolean>);
@@ -196,7 +199,7 @@ export const MarkerMapScreen = () => {
 
       showSnackbar(message);
 
-      if (supportedFeatures.toggling) {
+      if (supportedFeatures?.toggling) {
         if (showInfoWindow[title]) {
           markersRefs[title]?.current?.hideInfoWindow();
         } else {
@@ -212,7 +215,7 @@ export const MarkerMapScreen = () => {
     [
       logger,
       showSnackbar,
-      supportedFeatures.toggling,
+      supportedFeatures?.toggling,
       showInfoWindow,
       markersRefs,
     ]
@@ -292,7 +295,7 @@ export const MarkerMapScreen = () => {
     [customizableMarkerColorHue]
   );
 
-  const showStaticIconMarker = useMemo(
+  const showStaticIcon = useMemo(
     () =>
       !disabledOptions.markerAppearance.includes(
         DemoMarkerAppearance.LOCAL_ASSET_ICON
@@ -300,19 +303,29 @@ export const MarkerMapScreen = () => {
     [disabledOptions.markerAppearance]
   );
 
+  const staticIconMarkerTitle = useMemo(
+    () =>
+      showStaticIcon
+        ? MarkerIWTitles.STATIC_ICON_MARKER_NON_DRAGGABLE
+        : MarkerIWTitles.STATIC_MARKER_NON_DRAGGABLE,
+    [showStaticIcon]
+  );
+
   const staticColoredMarkerTitle = useMemo(
     () =>
-      supportedFeatures.draggable
+      supportedFeatures?.draggable
         ? MarkerIWTitles.STATIC_COLORED_MARKER_DRAGGABLE
         : MarkerIWTitles.STATIC_COLORED_MARKER_NON_DRAGGABLE,
-    [supportedFeatures.draggable]
+    [supportedFeatures?.draggable]
   );
 
   useEffect(() => {
-    if (!supportedFeatures.draggable) {
+    if (supportedFeatures?.draggable === false) {
       setCustomizableMarkerDraggable(false);
     }
-  }, [supportedFeatures.draggable]);
+  }, [supportedFeatures?.draggable]);
+
+  console.log(customizableMarkerColorRGB);
 
   return (
     <View style={demoStyles.rootContainer}>
@@ -327,6 +340,7 @@ export const MarkerMapScreen = () => {
 
             const providerName = omhMapRef.current?.getProviderName();
 
+            console.log('provider name ' + providerName);
             setSupportedFeatures(getSupportedFeatures(providerName));
             setDisabledOptions(getDisabledOptions(providerName));
 
@@ -389,23 +403,17 @@ export const MarkerMapScreen = () => {
 
           <OmhMarker
             ref={iconMarkerRef}
-            isVisible={showStaticIconMarker}
-            title={MarkerIWTitles.STATIC_ICON_MARKER_NON_DRAGGABLE}
+            title={staticIconMarkerTitle}
             position={{
               latitude: Constants.Maps.GREENWICH_COORDINATE.latitude + 0.0016,
               longitude: Constants.Maps.GREENWICH_COORDINATE.longitude + 0.002,
             }}
-            onPress={genMarkerOnPressHandler(
-              MarkerIWTitles.STATIC_ICON_MARKER_NON_DRAGGABLE
-            )}
-            onInfoWindowPress={genMarkerOnIWPressHandler(
-              MarkerIWTitles.STATIC_ICON_MARKER_NON_DRAGGABLE
-            )}
-            onInfoWindowClose={genMarkerOnIWCloseHandler(
-              MarkerIWTitles.STATIC_ICON_MARKER_NON_DRAGGABLE
-            )}
+            onPress={genMarkerOnPressHandler(staticIconMarkerTitle)}
+            onInfoWindowPress={genMarkerOnIWPressHandler(staticIconMarkerTitle)}
+            onInfoWindowClose={genMarkerOnIWCloseHandler(staticIconMarkerTitle)}
             markerZIndex={1.9}
-            icon={soccerBallIcon}
+            icon={showStaticIcon ? soccerBallIcon : undefined}
+            backgroundColor={!showStaticIcon ? 0x0000ff : undefined}
           />
 
           <OmhMarker
@@ -445,21 +453,21 @@ export const MarkerMapScreen = () => {
           />
 
           <PanelCheckbox
-            enabled={supportedFeatures.flat}
+            enabled={supportedFeatures?.flat}
             label="Flat"
             value={customizableMarkerFlat}
             onValueChange={setCustomizableMarkerFlat}
           />
 
           <PanelCheckbox
-            enabled={supportedFeatures.clickable}
+            enabled={supportedFeatures?.clickable}
             label="Clickable"
             value={customizableMarkerClickable}
             onValueChange={setCustomizableMarkerClickable}
           />
 
           <PanelCheckbox
-            enabled={supportedFeatures.draggable}
+            enabled={supportedFeatures?.draggable}
             label="Draggable"
             value={customizableMarkerDraggable}
             onValueChange={setCustomizableMarkerDraggable}
@@ -472,7 +480,7 @@ export const MarkerMapScreen = () => {
           />
 
           <Slider
-            disabled={!supportedFeatures.rotation}
+            disabled={!supportedFeatures?.rotation}
             label={`Rotation: ${customizableMarkerRotation.toFixed(0)}°`}
             onChange={zIndex => setCustomizableMarkerRotation(zIndex)}
             defaultValue={0}
@@ -482,7 +490,7 @@ export const MarkerMapScreen = () => {
           />
 
           <Slider
-            disabled={!supportedFeatures.anchor}
+            disabled={!supportedFeatures?.anchor}
             label={`Anchor U: ${(customizableMarkerAnchor.u * 100).toFixed(0)}%`}
             onChange={u =>
               setCustomizableMarkerAnchor({
@@ -497,7 +505,7 @@ export const MarkerMapScreen = () => {
           />
 
           <Slider
-            disabled={!supportedFeatures.anchor}
+            disabled={!supportedFeatures?.anchor}
             label={`Anchor V: ${(customizableMarkerAnchor.v * 100).toFixed(0)}%`}
             onChange={v =>
               setCustomizableMarkerAnchor({
@@ -512,7 +520,7 @@ export const MarkerMapScreen = () => {
           />
 
           <Slider
-            disabled={!supportedFeatures.alpha}
+            disabled={!supportedFeatures?.alpha}
             label={`Alpha: ${(customizableMarkerAlpha * 100).toFixed(0)}%`}
             onChange={alpha => setCustomizableMarkerAlpha(alpha)}
             defaultValue={1}
@@ -552,7 +560,7 @@ export const MarkerMapScreen = () => {
           />
 
           <Slider
-            disabled={!supportedFeatures.zIndex}
+            disabled={!supportedFeatures?.zIndex}
             label={`Z Index: ${customizableMarkerZIndex.toFixed(0)}`}
             onChange={zIndex => setCustomizableMarkerZIndex(zIndex)}
             defaultValue={0}

--- a/packages/core/src/components/marker/OmhMarker.ios.tsx
+++ b/packages/core/src/components/marker/OmhMarker.ios.tsx
@@ -1,9 +1,11 @@
 import React, {
   forwardRef,
   useCallback,
+  useEffect,
   useImperativeHandle,
   useMemo,
   useRef,
+  useState,
 } from 'react';
 import { MapMarker, Marker, MarkerPressEvent } from 'react-native-maps';
 import { OmhMarkerProps, OmhMarkerRef } from './OmhMarker.types';
@@ -14,6 +16,8 @@ import {
   MarkerDragStartEndEvent,
 } from 'react-native-maps/lib/sharedTypes';
 import { anchorToPoint } from '../../utils/anchorHelpers';
+import _ from 'lodash';
+import { OmhMapsModule } from '../../modules/core/OmhMapsModule.ios';
 
 /**
  * The OMH Marker component.
@@ -43,7 +47,20 @@ export const OmhMarker = forwardRef<OmhMarkerRef, OmhMarkerProps>(
     },
     forwardedRef
   ) => {
+    const provider = OmhMapsModule.getSelectedMapProvider();
+
     const markerRef = useRef<MapMarker | null>(null);
+
+    const [key, setKey] = useState(_.uniqueId());
+
+    useEffect(() => {
+      // Apple has a bug where only the initial value of the draggable prop is taken to the consideration.
+      // By using key prop we force refresh of the component. Note that markerRef?.current?.redraw() cant be used here
+      // either as the command is not implemented on the native side - another bug.
+      if (provider.name === 'Apple') {
+        setKey(_.uniqueId());
+      }
+    }, [provider, draggable]);
 
     useImperativeHandle(forwardedRef, () => ({
       showInfoWindow: () => {
@@ -135,6 +152,7 @@ export const OmhMarker = forwardRef<OmhMarkerRef, OmhMarkerProps>(
     return (
       isVisible && (
         <Marker
+          key={key}
           coordinate={position}
           title={title}
           description={snippet}

--- a/packages/core/src/components/marker/OmhMarker.ios.tsx
+++ b/packages/core/src/components/marker/OmhMarker.ios.tsx
@@ -1,11 +1,9 @@
 import React, {
   forwardRef,
   useCallback,
-  useEffect,
   useImperativeHandle,
   useMemo,
   useRef,
-  useState,
 } from 'react';
 import { MapMarker, Marker, MarkerPressEvent } from 'react-native-maps';
 import { OmhMarkerProps, OmhMarkerRef } from './OmhMarker.types';
@@ -16,8 +14,8 @@ import {
   MarkerDragStartEndEvent,
 } from 'react-native-maps/lib/sharedTypes';
 import { anchorToPoint } from '../../utils/anchorHelpers';
-import _ from 'lodash';
 import { OmhMapsModule } from '../../modules/core/OmhMapsModule.ios';
+import { useDraggableFix } from './OmhMarkerHelpers';
 
 /**
  * The OMH Marker component.
@@ -51,16 +49,7 @@ export const OmhMarker = forwardRef<OmhMarkerRef, OmhMarkerProps>(
 
     const markerRef = useRef<MapMarker | null>(null);
 
-    const [key, setKey] = useState(_.uniqueId());
-
-    useEffect(() => {
-      // Apple has a bug where only the initial value of the draggable prop is taken to the consideration.
-      // By using key prop we force refresh of the component. Note that markerRef?.current?.redraw() cant be used here
-      // either as the command is not implemented on the native side - another bug.
-      if (provider.name === 'Apple') {
-        setKey(_.uniqueId());
-      }
-    }, [provider, draggable]);
+    const key = useDraggableFix(provider.name, draggable);
 
     useImperativeHandle(forwardedRef, () => ({
       showInfoWindow: () => {

--- a/packages/core/src/components/marker/OmhMarkerHelpers.ts
+++ b/packages/core/src/components/marker/OmhMarkerHelpers.ts
@@ -1,0 +1,19 @@
+import { useMemo } from 'react';
+
+const standardKey = 'marker';
+const draggableKey = 'marker-draggable';
+const nonDraggableKey = 'marker-non-draggable';
+
+// Apple has a bug where only the initial value of the draggable prop is taken to the consideration.
+// By using key prop we force refresh of the component. Note that markerRef?.current?.redraw() cant be used here
+// either as the command is not implemented on the native side - another bug.
+export const useDraggableFix = (provider: string, draggable?: boolean) => {
+  const key = useMemo(() => {
+    if (provider === 'Apple') {
+      return draggable ? draggableKey : nonDraggableKey;
+    }
+    return standardKey;
+  }, [provider, draggable]);
+
+  return key;
+};


### PR DESCRIPTION
## Summary
Couple of bugs & changes:
- Fixed draggable prop for iOS - `react-native-maps` lib has a bug and only the initial value of the prop is considered. Implemented a workaround but it has a small unintended side effect, see demo.
- Fixed a bug with draggable checkbox - should be true for parity with AN demo.
- Show all reference markers on iOS - it does not support marker icon but QA thinks it would be still good to show the reference marker for parity

## Demo

Icon marker on Apple:
https://github.com/openmobilehub/react-native-omh-maps/assets/28648651/bec75519-03a9-4064-84de-20ff701ff899

Draggable side effect with info window on iOS:
https://github.com/openmobilehub/react-native-omh-maps/assets/28648651/de3c2b48-d633-4191-ab96-650872d1887f

## Checklist:

- [x] Documentation is up to date to reflect these changes
- [x] Created Unit tests

Closes: [OMHD-370](https://callstackio.atlassian.net/browse/OMHD-370)
