### PR TITLE
fix: marker not removing native component from map upon re-creation but not detachment from RN tree

### DIFF
--- a/apps/sample-app/src/screens/demos/MarkerMapScreen.tsx
+++ b/apps/sample-app/src/screens/demos/MarkerMapScreen.tsx
@@ -14,13 +14,14 @@ import {
   MarkerDragEndEvent,
   MarkerDragEvent,
   MarkerDragStartEvent,
+  OmhAnchor,
   OmhMapView,
   OmhMapViewRef,
   OmhMarker,
   OmhMarkerConstants,
   OmhMarkerRef,
-  OmhAnchor,
 } from '@openmobilehub/maps-core';
+
 import soccerBallIcon from '../../assets/img/soccer_ball.bmp';
 import { PanelCheckbox } from '../../components/controls/PanelCheckbox';
 import Picker from '../../components/controls/Picker';
@@ -29,12 +30,13 @@ import useLogger from '../../hooks/useLogger';
 import useSnackbar from '../../hooks/useSnackbar';
 import { demoStyles } from '../../styles/demoStyles';
 import { Constants } from '../../utils/Constants';
-import { formatPosition, rgbToInt } from '../../utils/converters';
 import {
   androidProvidersWithout,
   iOSProvidersWithout,
   isFeatureSupported,
 } from '../../utils/SupportUtils';
+import { formatPosition, rgbToInt } from '../../utils/converters';
+
 import IOS_SUPPORTED_PROVIDERS = Constants.Demo.IOS_SUPPORTED_PROVIDERS;
 import ANDROID_SUPPORTED_PROVIDERS = Constants.Demo.ANDROID_SUPPORTED_PROVIDERS;
 

--- a/packages/core/android/src/main/java/com/openmobilehub/android/rn/maps/core/viewmanagers/RNOmhMapsCoreViewManagerImpl.kt
+++ b/packages/core/android/src/main/java/com/openmobilehub/android/rn/maps/core/viewmanagers/RNOmhMapsCoreViewManagerImpl.kt
@@ -118,7 +118,7 @@ class RNOmhMapsCoreViewManagerImpl(private val reactContext: ReactContext) {
             }
         }
     }
-
+    
     fun removeViewAt(index: Int) {
         // note: on old RN architecture, RN unmounts the fragment first, and then the children
         // which causes a NullPointerException when unmountEntity() triggers calls to underlying

--- a/packages/core/android/src/main/java/com/openmobilehub/android/rn/maps/core/viewmanagers/RNOmhMapsMarkerViewManagerImpl.kt
+++ b/packages/core/android/src/main/java/com/openmobilehub/android/rn/maps/core/viewmanagers/RNOmhMapsMarkerViewManagerImpl.kt
@@ -245,25 +245,30 @@ class RNOmhMapsMarkerViewManagerImpl {
     }
 
     fun showInfoWindow(entity: OmhMarkerEntity) {
-      toggleInfoWindow(entity, true)
+        toggleInfoWindow(entity, true)
     }
 
     fun hideInfoWindow(entity: OmhMarkerEntity) {
-      toggleInfoWindow(entity, false)
+        toggleInfoWindow(entity, false)
+    }
+
+    fun remove(entity: OmhMarkerEntity) {
+        handleMarkerRemoved(entity)
+        entity.unmountEntity()
     }
 
     private fun toggleInfoWindow(entity: OmhMarkerEntity, visible: Boolean) {
-      entity.queueOnMapReadyAction { marker, _, omhMapView ->
-        UiThreadUtil.runOnUiThread {
-          if (visible) {
-            marker?.showInfoWindow()
-          } else {
-            marker?.hideInfoWindow()
-          }
+        entity.queueOnMapReadyAction { marker, _, omhMapView ->
+            UiThreadUtil.runOnUiThread {
+                if (visible) {
+                    marker?.showInfoWindow()
+                } else {
+                    marker?.hideInfoWindow()
+                }
 
-          omhMapView?.getView()?.manuallyLayoutView()
+                omhMapView?.getView()?.manuallyLayoutView()
+            }
         }
-      }
     }
 
     companion object {

--- a/packages/core/android/src/newarch/java/com/openmobilehub/android/rn/maps/core/RNOmhMapsMarkerViewManager.kt
+++ b/packages/core/android/src/newarch/java/com/openmobilehub/android/rn/maps/core/RNOmhMapsMarkerViewManager.kt
@@ -114,6 +114,10 @@ class RNOmhMapsMarkerViewManager :
       omhMapMarkerComponentManagerImpl.hideInfoWindow(view)
     }
 
+    override fun remove(view: OmhMarkerEntity) {
+        omhMapMarkerComponentManagerImpl.remove(view)
+    }
+
     override fun getName(): String = RNOmhMapsMarkerViewManagerImpl.NAME
 
     override fun getExportedCustomDirectEventTypeConstants(): Map<String, Any> {

--- a/packages/core/android/src/oldarch/java/com/openmobilehub/android/rn/maps/core/RNOmhMapsMarkerViewManager.kt
+++ b/packages/core/android/src/oldarch/java/com/openmobilehub/android/rn/maps/core/RNOmhMapsMarkerViewManager.kt
@@ -26,6 +26,9 @@ class RNOmhMapsMarkerViewManager :
         "hideInfoWindow" -> {
           omhMapMarkerComponentManagerImpl.hideInfoWindow(root)
         }
+        "remove" -> {
+          omhMapMarkerComponentManagerImpl.remove(view)
+        }
       }
     }
 

--- a/packages/core/src/components/marker/OmhMarker.tsx
+++ b/packages/core/src/components/marker/OmhMarker.tsx
@@ -1,4 +1,9 @@
-import React, { forwardRef, useImperativeHandle, useMemo } from 'react';
+import React, {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+} from 'react';
 import { PixelRatio } from 'react-native';
 
 import useOmhMarkerOSMFix from '../../hooks/useOmhMarkerOSMFix';
@@ -55,6 +60,16 @@ export const OmhMarker = forwardRef<OmhMarkerRef, OmhMarkerProps>(
       () => (_backgroundColor === undefined ? -1 : _backgroundColor),
       [_backgroundColor]
     );
+
+    // unmount effect - remove marker
+    useEffect(() => {
+      return () => {
+        if (nativeComponentRef.current) {
+          // eslint-disable-next-line react-hooks/exhaustive-deps
+          Commands.remove(nativeComponentRef.current);
+        }
+      };
+    }, []);
 
     return (
       <RNOmhMapsMarkerNativeComponent

--- a/packages/core/src/components/marker/RNOmhMapsMarkerNativeComponent.ts
+++ b/packages/core/src/components/marker/RNOmhMapsMarkerNativeComponent.ts
@@ -68,10 +68,11 @@ export interface NativeCommands {
   hideInfoWindow: (
     viewRef: React.ElementRef<RNOmhMapsMarkerNativeComponent>
   ) => void;
+  remove: (viewRef: React.ElementRef<RNOmhMapsMarkerNativeComponent>) => void;
 }
 
 export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
-  supportedCommands: ['showInfoWindow', 'hideInfoWindow'],
+  supportedCommands: ['showInfoWindow', 'hideInfoWindow', 'remove'],
 });
 
 export default codegenNativeComponent<NativeOmhMarkerProps>(


### PR DESCRIPTION
## Summary

This PR adds in handling of unmount event from the `OmhMarker` to ensure that the native entity is removed from the map. This is apparently needed as changing markers rendered in a map expression (as array) does not cause unmounts, but the native markers from previous RN tree are left behind.

## Demo

N/A

## Checklist:

- [x] Documentation is up to date to reflect these changes
- [x] Created Unit tests