### PR TITLE
OMHD-367/OMHD-368: Marker fixes

### DIFF
--- a/apps/sample-app/src/screens/demos/MarkerMapScreen.tsx
+++ b/apps/sample-app/src/screens/demos/MarkerMapScreen.tsx
@@ -58,7 +58,7 @@ const getSupportedFeatures = (currentMapProvider?: string) => {
     zIndex: isFeatureSupported(
       currentMapProvider,
       Platform.OS === 'ios'
-        ? IOS_SUPPORTED_PROVIDERS
+        ? iOSProvidersWithout(['Apple'])
         : androidProvidersWithout(['OpenStreetMap', 'Mapbox', 'AzureMaps'])
     ),
     draggable: isFeatureSupported(

--- a/docs/docs/apple.md
+++ b/docs/docs/apple.md
@@ -101,7 +101,7 @@ Comments for partially supported properties:
 | isFlat                |     ❌     |
 | rotation              |     ❌     |
 | backgroundColor       |     ✅     |
-| markerZIndex          |     ✅     |
+| markerZIndex          |     ❌     |
 | icon                  |     ❌     |
 | consumeMarkerClicks   |     ❌     |
 | onPress               |     ✅     |

--- a/packages/core/src/components/marker/OmhMarker.ios.tsx
+++ b/packages/core/src/components/marker/OmhMarker.ios.tsx
@@ -16,6 +16,7 @@ import {
 import { anchorToPoint } from '../../utils/anchorHelpers';
 import { OmhMapsModule } from '../../modules/core/OmhMapsModule.ios';
 import { useDraggableFix } from './OmhMarkerHelpers';
+import { OmhMarkerConstants } from './OmhMarkerConstants';
 
 /**
  * The OMH Marker component.
@@ -68,9 +69,13 @@ export const OmhMarker = forwardRef<OmhMarkerRef, OmhMarkerProps>(
     }, [infoWindowAnchor]);
 
     const pinColor = useMemo(() => {
-      if (!backgroundColor) return undefined;
-      return omhColorToString(backgroundColor);
-    }, [backgroundColor]);
+      if (icon) return undefined;
+      if (backgroundColor) return omhColorToString(backgroundColor);
+      // There is an issue in the react-native-maps library.
+      // When the icon changes to undefined and color is undefined, the marker does not update.
+      // To fix this, we set a default color when the icon is undefined.
+      return OmhMarkerConstants.DEFAULT_COLOR;
+    }, [backgroundColor, icon]);
 
     const handleOnPress = useCallback(
       (event: MarkerPressEvent) => {

--- a/packages/core/src/components/marker/OmhMarker.ios.tsx
+++ b/packages/core/src/components/marker/OmhMarker.ios.tsx
@@ -35,7 +35,6 @@ export const OmhMarker = forwardRef<OmhMarkerRef, OmhMarkerProps>(
       isFlat,
       rotation,
       backgroundColor,
-      markerZIndex,
       icon,
       onPress,
       onDragStart,
@@ -153,7 +152,6 @@ export const OmhMarker = forwardRef<OmhMarkerRef, OmhMarkerProps>(
           pinColor={pinColor}
           flat={isFlat}
           rotation={rotation}
-          zIndex={markerZIndex}
           icon={icon}
           onPress={handleOnPress}
           onDragStart={handleOnDragStart}

--- a/packages/core/src/components/marker/OmhMarkerConstants.ts
+++ b/packages/core/src/components/marker/OmhMarkerConstants.ts
@@ -11,4 +11,5 @@ export namespace OmhMarkerConstants {
   export const ANCHOR_TOP_RIGHT = { u: 0, v: 1 };
   export const ANCHOR_BOTTOM_LEFT = { u: 1, v: 0 };
   export const ANCHOR_BOTTOM_RIGHT = { u: 0, v: 0 };
+  export const DEFAULT_COLOR = '#FF4A4A';
 }


### PR DESCRIPTION
## Summary

This PR fixes two tickets for iOS Markers:
- AppleMaps - zIndex - cannot be fixed due to the issues in react-native-maps
- GoogleMaps - appearance - fixed with the default color workaround (see demo).

## Demo

https://github.com/openmobilehub/react-native-omh-maps/assets/23010554/e7f8b49e-b17a-4614-8281-d7daa1a41fb9

## Checklist:

- [x] Documentation is up to date to reflect these changes
- [x] Created Unit tests

Closes: [OMHD-368](https://callstackio.atlassian.net/browse/OMHD-367)
Closes: [OMHD-368](https://callstackio.atlassian.net/browse/OMHD-368)
