### PR TITLE
CI: Fix setup secrets step

### DIFF
--- a/.github/scripts/setup_secrets.sh
+++ b/.github/scripts/setup_secrets.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 mkdir -p ~/.gradle
 echo "MAPBOX_DOWNLOADS_TOKEN=$1" >> ~/.gradle/gradle.properties
-echo "MAPS_API_KEY=$2" >> ./apps/sample-app/android/local.properties
+echo "GOOGLE_MAPS_API_KEY=$2" >> ./apps/sample-app/android/local.properties
 echo "MAPBOX_PUBLIC_TOKEN=$3" >> ./apps/sample-app/android/local.properties
 echo "AZURE_MAPS_SUBSCRIPTION_KEY=$4" >> ./apps/sample-app/android/local.properties


### PR DESCRIPTION
## Summary

This PR fixes `setup_secrets` script.
Previously it was working as we were caching whole builds.

## Demo

n/a

## Checklist:

- [x] Documentation is up to date to reflect these changes
- [x] Created Unit tests
