### PR TITLE
fix: strip OSM native component

### DIFF
--- a/packages/plugin-openstreetmap/android/build.gradle
+++ b/packages/plugin-openstreetmap/android/build.gradle
@@ -116,7 +116,7 @@ dependencies {
 if (isNewArchitectureEnabled()) {
     react {
         jsRootDir = file("../src/")
-        libraryName = "RNOmhMapsPluginOpenstreetmapView"
+        libraryName = "RNOmhMapsPluginOpenstreetmap"
         codegenJavaPackageName = "com.openmobilehub.android.rn.maps.plugin.openstreetmap"
     }
 }

--- a/packages/plugin-openstreetmap/src/RNOmhMapsPluginOpenstreetmapViewNativeComponent.ts
+++ b/packages/plugin-openstreetmap/src/RNOmhMapsPluginOpenstreetmapViewNativeComponent.ts
@@ -1,8 +1,0 @@
-import type { ViewProps } from 'react-native';
-import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
-
-interface NativeProps extends ViewProps {}
-
-export default codegenNativeComponent<NativeProps>(
-  'RNOmhMapsPluginOpenstreetmapView'
-);


### PR DESCRIPTION
## Summary

This PR strips off an obsolete OSM plugin native component.

## Demo

N/A

## Checklist:

- [x] Documentation is up to date to reflect these changes
- [x] Created Unit tests
