### PR TITLE
fix: app crash for getLastLocation

### DIFF
--- a/packages/core/src/modules/location/OmhMapsLocationModule.ios.ts
+++ b/packages/core/src/modules/location/OmhMapsLocationModule.ios.ts
@@ -33,5 +33,5 @@ const getLocation = async (
 
 export const OmhMapsLocationModule: IOmhMapsLocationModule = {
   getCurrentLocation: async () => getLocation({ maximumAge: 0 }),
-  getLastLocation: () => getLocation({ maximumAge: Infinity }),
+  getLastLocation: () => getLocation({ maximumAge: Number.MAX_SAFE_INTEGER }),
 };


### PR DESCRIPTION
## Summary

Passing `Infinity` to `getCurrentPosition` method was causing app crash. 
Fixes #112 